### PR TITLE
アイテム詳細欄トグルボタンの押下不可バグ修正

### DIFF
--- a/html/wp-content/themes/lol_dictionary/assets/json/item_detail.json
+++ b/html/wp-content/themes/lol_dictionary/assets/json/item_detail.json
@@ -991,7 +991,7 @@
     },
     "4633": {
         "passives": [
-            "<passive>ヴォイドの邪念<\/passive>敵チャンピオンとの<keyword>戦闘状態<\/keyword>まで、自身の与えるダメージが毎秒<bs>2%<\/bs>増加する。<bs>（最大8%）<\/bs>効果が最大になっている間は<ls>オムニヴァンプが<melee>10%<\/melee><ranged>6%<\/ranged><\/ls>増加する。",
+            "<passive>ヴォイドの邪念<\/passive>敵チャンピオンとの<keyword>戦闘状態<\/keyword>の間、自身の与えるダメージが毎秒<bs>2%<\/bs>増加する。<bs>（最大8%）<\/bs>効果が最大になっている間は<ls>オムニヴァンプが<melee>10%<\/melee><ranged>6%<\/ranged><\/ls>増加する。",
             "<passive>ヴォイドの浸食<\/passive><hp>2%[増加HP]<\/hp>だけ<ap>AP<\/ap>を獲得する。"
         ],
         "actives": []

--- a/html/wp-content/themes/lol_dictionary/page-item-dic.php
+++ b/html/wp-content/themes/lol_dictionary/page-item-dic.php
@@ -221,7 +221,7 @@ get_header(); ?>
 								<h3 class="p-item-card-admin-note__heading">誤りの報告／問い合わせフォーム（仮）</h3>
 								<div class="l-section-small">
 									<?php
-									echo do_shortcode('[contact-form-7 id="602b0cb" title="総合コンタクト"]'); ?>
+									echo do_shortcode('[contact-form-7 id="dd3209b" title="総合コンタクト"]'); ?>
 								</div>
 							</div>
 

--- a/src/js/contact_form.js
+++ b/src/js/contact_form.js
@@ -7,7 +7,6 @@ const textAreas = document.querySelectorAll('input[type="text"], textarea', 'lab
 textAreas.forEach((textArea) => {
 
     textArea.addEventListener('click', () => {
-        console.log('click');
         textArea.focus();
     });
 });

--- a/src/js/item_detail.js
+++ b/src/js/item_detail.js
@@ -46,10 +46,6 @@ itemButton.forEach((button) => {
         // bodyにスクロールを禁止
         document.body.style.overflow = 'hidden';
     });
-
-    button.addEventListener('focus', function() {
-        console.log('focus');
-    });
 });
 
 modal.addEventListener('click', function() {
@@ -86,8 +82,6 @@ const meleeRangeToggleButtons = document.querySelectorAll('.js-toggle-melee-rang
 meleeRangeToggleButtons.forEach((button) => {
 
     button.addEventListener('click', function() {
-
-        console.log('toggle');
 
         // この要素の親戚の .js-ability を取得
         const parentItemCard = this.closest('.js-item-button');

--- a/src/js/item_detail.js
+++ b/src/js/item_detail.js
@@ -16,13 +16,15 @@ itemButton.forEach((button) => {
             return;
         }
 
+        const isToggleButton = event.target.closest('.c-button-toggle');
+
         // 最後にクリックしたカードを保存
         lastClickedCard = this;
 
         // 既に詳細モードの場合は処理をスキップ
         // input[type="submit"]の場合はpreventDefaultしない
         if (this.classList.contains('is-detail-mode')) {
-            if (event.target.tagName === 'INPUT' && event.target.type === 'submit') {
+            if (event.target.tagName === 'INPUT' && event.target.type === 'submit' || isToggleButton) {
                 return;
             }
             event.preventDefault();
@@ -84,6 +86,8 @@ const meleeRangeToggleButtons = document.querySelectorAll('.js-toggle-melee-rang
 meleeRangeToggleButtons.forEach((button) => {
 
     button.addEventListener('click', function() {
+
+        console.log('toggle');
 
         // この要素の親戚の .js-ability を取得
         const parentItemCard = this.closest('.js-item-button');

--- a/src/scss/object/component/_button.scss
+++ b/src/scss/object/component/_button.scss
@@ -28,6 +28,7 @@
     align-items: center;
     gap: 5px;
     width: fit-content;
+    cursor: pointer;
 
     .slider {
         display: block;

--- a/src/scss/object/project/_item.scss
+++ b/src/scss/object/project/_item.scss
@@ -339,6 +339,10 @@
             font-style: italic;
             font-size: 12px;
         }
+
+        input {
+            display: none;
+        }
     }
 
 		&__form {


### PR DESCRIPTION
### 対応内容
- トグルボタンを押してる場合のみ、クリックイベントを回避しないように修正

### 今後の対応
- そもそもアイテム詳細欄が全てaタグで囲まれてることが問題なので、ここを要修正